### PR TITLE
Build a separate test binary per access pattern

### DIFF
--- a/software/src/Makefile
+++ b/software/src/Makefile
@@ -7,16 +7,24 @@ BINARY_OPT=-static -specs=htif_nano.specs
 OBJECT_DUMP_OPT=--disassemble-all
 
 TARGET=mempress-rocc
-TARGET_RISCV=$(TARGET).riscv
-TARGET_OBJDUMP=$(TARGET).riscv.dump
+# burst omitted: HW path in reqgen is still a stub. Build manually with -DPAT_BURST.
+PATTERNS=stride rand
+
+TARGET_RISCV=$(foreach p,$(PATTERNS),$(TARGET)-$(p).riscv)
+TARGET_OBJDUMP=$(foreach p,$(PATTERNS),$(TARGET)-$(p).riscv.dump)
 JUNK += $(TARGET_RISCV) $(TARGET_OBJDUMP)
 
 all: $(TARGET_RISCV) $(TARGET_OBJDUMP)
 
-$(TARGET_RISCV): mempress-rocc.c
-	$(RISCV_CC) $(BINARY_OPT) -o $@ $^
+# Map each binary's pattern suffix to its -D flag (see mempress-rocc.c).
+$(TARGET)-stride.riscv: PAT_FLAG=-DPAT_STRIDE
+$(TARGET)-burst.riscv: PAT_FLAG=-DPAT_BURST
+$(TARGET)-rand.riscv: PAT_FLAG=-DPAT_RAND
 
-$(TARGET_OBJDUMP): $(TARGET_RISCV)
+$(TARGET)-%.riscv: mempress-rocc.c
+	$(RISCV_CC) $(BINARY_OPT) $(PAT_FLAG) -o $@ $^
+
+$(TARGET)-%.riscv.dump: $(TARGET)-%.riscv
 	$(RISCV_OBJDUMP) $(OBJECT_DUMP_OPT) $< > $@
 
 .PHONY: clean

--- a/software/src/mempress-rocc.c
+++ b/software/src/mempress-rocc.c
@@ -30,6 +30,25 @@ enum STREAM_TYPE {
     RAND_WR = 5
 };
 
+// Select which access pattern this binary exercises at compile time.
+// Even-indexed streams use BASE_RD, odd-indexed streams use BASE_WR.
+#if defined(PAT_STRIDE)
+  #define PAT_NAME "stride"
+  #define BASE_RD STRIDE_RD
+  #define BASE_WR STRIDE_WR
+#elif defined(PAT_BURST)
+  // burst HW in reqgen is still a stub, so not built by default (see Makefile).
+  #define PAT_NAME "burst"
+  #define BASE_RD BURST_RD
+  #define BASE_WR BURST_WR
+#elif defined(PAT_RAND)
+  #define PAT_NAME "rand"
+  #define BASE_RD RAND_RD
+  #define BASE_WR RAND_WR
+#else
+  #error "build with exactly one of -DPAT_STRIDE / -DPAT_BURST / -DPAT_RAND"
+#endif
+
 int main() {
   printf("main() started\n");
 
@@ -54,8 +73,8 @@ int main() {
   enum STREAM_TYPE stream_type[MAX_STREAMS];
   for (ii = 0; ii < MAX_STREAMS; ii++) {
       int r = ii % 2;
-      if (r == 0) stream_type[ii] = RAND_RD;
-      else stream_type[ii] = RAND_WR;
+      if (r == 0) stream_type[ii] = BASE_RD;
+      else stream_type[ii] = BASE_WR;
   }
 
   int mem_size = addr_range * stream_cnt;


### PR DESCRIPTION
[`mempress-rocc.c`](https://github.com/ucb-bar/mempress/blob/de90faa3b4e01f4ca76c592367c5c19b774ac8e8/software/src/mempress-rocc.c) only tested the random pattern. This adds compile-time selection (`-DPAT_STRIDE` / `-DPAT_RAND`) so each pattern builds as its own binary (`mempress-rocc-stride.riscv`, `mempress-rocc-rand.riscv`).

Both build cleanly; `stride`/`rand` verified at the address level on VCS ([`MempressRocketConfig`](https://github.com/ucb-bar/mempress/blob/de90faa3b4e01f4ca76c592367c5c19b774ac8e8/chipyard/MempressConfigs.scala#L7-L15)).

`burst` is scaffolded (`-DPAT_BURST`) but not built by default; its [`reqgen`](https://github.com/ucb-bar/mempress/blob/de90faa3b4e01f4ca76c592367c5c19b774ac8e8/src/main/scala/reqgen.scala#L99-L104) hardware path is still a stub. Left to a follow-up.

Renames the test binary (mempress-rocc.riscv → mempress-rocc-{stride,rand}.riscv). Chipyard's [`.github/scripts/run-tests.sh`](https://github.com/ucb-bar/chipyard/blob/0acc1e1de2d3284bcd4d876956932a013ffe1949/.github/scripts/run-tests.sh#L76-L79) references the old name and must be updated when the submodule is bumped.